### PR TITLE
Issue6 code formatting

### DIFF
--- a/_episodes/01-basics.md
+++ b/_episodes/01-basics.md
@@ -16,6 +16,7 @@ It is very easy to do basic math in Python.
 ```python
 print(5 + 1)
 ```
+{: .language-python}
 ```
 6
 ```
@@ -27,7 +28,7 @@ Notice how leaving out `print()` gives us the same result as above.
 ```python
 5 + 1
 ```
-
+{: .language-python}
 ```
 6
 ```
@@ -41,7 +42,7 @@ Python can do all of the normal basic math operations you'd expect.
 4 * 6
 14 / 3
 ```
-
+{: .language-python}
 ```
 8
 -7
@@ -55,7 +56,7 @@ You can also use it to more complicated operations, like exponentiation (`**`):
 ```python
 5 ** 2
 ```
-
+{: .language-python}
 ```
 25
 ```
@@ -69,7 +70,7 @@ Remainder division (`%`), gives the remainder after division.
 5 // 2  # floor division
 5 % 2   # remainder division
 ```
-
+{: .language-python}
 ```
 2
 1
@@ -81,7 +82,7 @@ Python follows the normal order of operations for math.
 ```python
 4 + 1 * 6
 ```
-
+{: .language-python}
 ```
 10
 ```
@@ -94,7 +95,7 @@ Note that there is no limit to the number of parentheses you can use.
 ```python
 (4 + 1) * 6
 ```
-
+{: .language-python}
 ```
 30
 ```
@@ -110,7 +111,7 @@ We can set them with the `=` sign.
 ```python
 weight_kg = 55
 ```
-
+{: .language-python}
 
 If we want to retrieve the information we've stored, 
 we can do it by simply typing the name of the variable again.
@@ -118,7 +119,7 @@ we can do it by simply typing the name of the variable again.
 ```python
 weight_kg
 ```
-
+{: .language-python}
 ```
 55
 ```
@@ -129,7 +130,7 @@ We can perform math on variables the same way we would normally.
 ```python
 print('weight in pounds:', 2.2 * weight_kg)
 ```
-
+{: .language-python}
 ```
 weight in pounds: 121.00000000000001
 ```
@@ -144,7 +145,7 @@ We can also change a variable’s value by assigning it a new one:
 weight_lb = 2.2 * weight_kg
 print(weight_lb)
 ```
-
+{: .language-python}
 ```
 121.00000000000001
 ```
@@ -159,7 +160,7 @@ weight_kg = 10000
 print('after updating, weight_kg ending value is', weight_kg)
 print('weight in lb ending value is', weight_lb)
 ```
-
+{: .language-python}
 ```
 weight_kg starting value is 55
 after updating, weight_kg ending value is 10000
@@ -181,7 +182,7 @@ we will need to perform this operation explicitly.
 weight_lb = weight_kg * 2.2
 print('new value for weight_lb is', weight_lb)
 ```
-
+{: .language-python}
 ```
 new value for weight_lb is 22000.0
 ```
@@ -220,7 +221,7 @@ For instance, what happens if we accidentally don't finish a command?
 ```python
 1 + 
 ```
-
+{: .language-python}
 ```
 SyntaxError: invalid syntax (<ipython-input-15-70475fc083df, line 1)
   File "<ipython-input-15-70475fc083df", line 1
@@ -290,7 +291,7 @@ It will print the data type of whatever is inside the parentheses.
 type('this is a string')
 type("this is also a string")
 ```
-
+{: .language-python}
 ```
 str
 str
@@ -310,7 +311,7 @@ multiline = '''
 print(multiline)
 type(multiline)
 ```
-
+{: .language-python}
 ```
 This string
 spans
@@ -329,7 +330,7 @@ For instance, we can even use the `+` sign to put strings together!
 'some text' + 'MORE TEXT'
 'repetition' * 3
 ```
-
+{: .language-python}
 ```
 'some textMORE TEXT'
 'repetitionrepetitionrepetition'
@@ -342,7 +343,7 @@ Attempting to add a string to a number doesn't work!
 ```python
 '5' + 5
 ```
-
+{: .language-python}
 ```
 ---------------------------------------------------------------------------
 TypeError                                 Traceback (most recent call last)
@@ -365,7 +366,7 @@ type(5)
 type(-1000)
 type(6 + -33)
 ```
-
+{: .language-python}
 ```
 int
 int
@@ -378,7 +379,7 @@ But what happens when we perform a math operation that would result in a decimal
 ```python
 type(10 / 3)
 ```
-
+{: .language-python}
 ```
 float
 ```
@@ -392,7 +393,7 @@ To explicitly set a number as a float, just add a decimal point.
 type(1.3)
 type(22.)
 ```
-
+{: .language-python}
 ```
 float
 float
@@ -408,7 +409,7 @@ Unsurprisingly, these are defined as `True` and `False`.
 type(True)
 type(False)
 ```
-
+{: .language-python}
 ```
 bool
 bool
@@ -421,7 +422,7 @@ We will revisit `None` in more detail later, so for now, just be aware it exists
 ```python
 type(None)
 ```
-
+{: .language-python}
 ```
 NoneType
 ```
@@ -440,7 +441,7 @@ NoneType
 > ```python
 > print(int('5') + 5)
 > ```
-> 
+> {: .language-python}
 > ```
 > 10
 > ```
@@ -458,12 +459,13 @@ NoneType
 > Use only the commands shown above.
 > 
 > ```python
-> 1 + '1' == '11'  
-> '6' - 7 == -1  
-> 7.23 == 7  
-> '5' == True  
-> 4 / 1.3 == 4  
+> 1 + '1' == '11'
+> '6' - 7 == -1
+> 7.23 == 7
+> '5' == True
+> 4 / 1.3 == 4
 > ```
+> {: .language-python}
 {: .challenge}
 
 > ## Data type conversion pitfalls

--- a/_episodes/01-basics.md
+++ b/_episodes/01-basics.md
@@ -194,16 +194,17 @@ Don't know how something works?
 Try it and find out!
 
 > ## Where are variables stored?
+>
 > Your computer has two places where it stores information: hard disk and memory.
 > What are they and what are they used for?
 > Where do variables get stored?
-> 
+>
 > Memory is where temporary information on your computer gets placed.
 > It is very fast and easy to access, but has one important drawback: 
 > data here is erased when your program quits or your computer shuts down.
 > All information you save as variables in Python will be stored in memory! 
 > When programming, we always need to save our data as a file (on our hard disk) if we want to keep it!
-> 
+>
 > Your computer's hard disk is used to store information long-term.
 > This is where files get stored, and the information on your hard drive is more or less permanent.
 > Hard drives can also store lots of data very cheaply - a terabyte of hard drive space is very cheap, whereas the same amount of memory costs a lot more.

--- a/_episodes/02-scripts.md
+++ b/_episodes/02-scripts.md
@@ -24,7 +24,7 @@ Enter the following text in a text editor and save it under any name you like
 ```python
 print('it works!!!')
 ```
-
+{: .language-python}
 
 We can now run this program in several ways.
 If we were to open up a terminal in the folder where we had saved our program, 
@@ -47,7 +47,7 @@ it works!!!
 > print('this involves print')
 > 'this does not'
 > ```
-> 
+> {: .language-python}
 > What gets printed if you execute this as a script?
 > What gets printed if you execute things line by line?
 > Using this information, what's the point of `print()`?
@@ -65,7 +65,7 @@ I've called my script `test.py` as an example.
 ```
 !python3 test.py
 ```
-
+{: .language-python}
 ```
 it works!!!
 ```
@@ -83,7 +83,7 @@ To access a package, we need to `import` it.
 ```python
 import sys
 ```
-
+{: .language-python}
 
 You'll notice that there's no output.
 Only one thing is changed:
@@ -99,13 +99,13 @@ import sys
 
 print('we typed: ', sys.argv)
 ```
-
+{: .language-python}
 
 We can then execute this program with:
 ```
 !python3 test.py word1 word2 3
 ```
-
+{: .language-python}
 ```
 we typed: ['test.py', 'word1', 'word2', '3']
 ```

--- a/_episodes/02-scripts.md
+++ b/_episodes/02-scripts.md
@@ -36,6 +36,7 @@ it works!!!
 {: .output}
 
 > ## What's the point of print()?
+>
 > We saw earlier that there was no difference between printing something with `print()`
 > and just entering a command on the command line.
 > But is this really the case?
@@ -96,7 +97,6 @@ Let's make a new script called `command-args.py` to try this out.
 
 ```python
 import sys
-
 print('we typed: ', sys.argv)
 ```
 {: .language-python}

--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -19,7 +19,7 @@ A list is a set of objects enclosed by a set of square brackets (`[]`).
 example = [1, 2, 4, 5]
 example
 ```
-
+{: .language-python}
 ```
 [1, 2, 4, 5]
 ```
@@ -31,7 +31,7 @@ Note that a list can hold any type of item, even other lists!
 example = [1, True, None, ["word", 123], "test"]
 example
 ```
-
+{: .language-python}
 ```
 [1, True, None, ['word', 123], 'test']
 ```
@@ -57,7 +57,7 @@ example[1]
 # fetch the list inside the list
 example[3]
 ```
-
+{: .language-python}
 ```
 1
 True
@@ -71,7 +71,7 @@ A colon by itself means fetch everything.
 ```python
 example[:]
 ```
-
+{: .language-python}
 ```
 [1, True, None, ['word', 123], 'test']
 ```
@@ -82,7 +82,7 @@ A colon on the right side of an index means everything after the specified index
 ```python
 example[2:]
 ```
-
+{: .language-python}
 ```
 [None, ['word', 123], 'test']
 ```
@@ -93,7 +93,7 @@ A colon on the left side  of an index means everyting before, but not including,
 ```python
 example[:2]
 ```
-
+{: .language-python}
 ```
 [1, True]
 ```
@@ -108,7 +108,7 @@ example[-1]
 # everything except the last two elements
 example[:-2]
 ```
-
+{: .language-python}
 ```
 'test'
 [1, True, None]
@@ -120,7 +120,7 @@ Note that we can use the index multiple times to retrieve information from neste
 ```python
 example[3][0]
 ```
-
+{: .language-python}
 ```
 'word'
 ```
@@ -131,7 +131,7 @@ If we index out of range, it is an error:
 ```python
 example[5]
 ```
-
+{: .language-python}
 ```
 ---------------------------------------------------------------------------
 IndexError                                Traceback (most recent call last)
@@ -147,7 +147,7 @@ We can also add two lists together to create a larger list.
 ```python
 [45, 2] + [3]
 ```
-
+{: .language-python}
 ```
 [45, 2, 3]
 ```
@@ -165,7 +165,7 @@ list2 += [5, 6, 7]
 print('List 2 is: ', list2)
 print('List 1 is: ', list1)
 ```
-
+{: .language-python}
 ```
 List 2 is:  [1, 2, 3, 4, 5, 6, 7]
 List 1 is:  [1, 2, 3, 4, 5, 6, 7]
@@ -188,7 +188,7 @@ Two objects will not have the same ID unless they are the same object.
 id(list1)
 id(list2)
 ```
-
+{: .language-python}
 ```
 140319556870408
 140319556870408
@@ -199,15 +199,15 @@ In order to create `list2` as a unique copy of `list1`.
 We have to use the `.copy()` method.
 
 ```python
-list1 = [1, 2, 3, 4]                                                                          
-list2 = list1.copy()                                                                          
-list2 += [5, 6, 7]                                                                            
-print('List 2 is: ', list2)                                                                   
+list1 = [1, 2, 3, 4]
+list2 = list1.copy()
+list2 += [5, 6, 7]
+print('List 2 is: ', list2)
 print('List 1 is: ', list1)
 id(list2)
 id(list1)
 ```
-
+{: .language-python}
 ```
 List 2 is:  [1, 2, 3, 4, 5, 6, 7]
 List 1 is:  [1, 2, 3, 4]
@@ -225,16 +225,17 @@ Other frequently used methods of lists include `.append()`:
 ```python
 list1.append(77)
 ```
-
+{: .language-python}
 ```
 [1, 2, 3, 4, 77]
 ```
 {: .output}
+
 ```python
 # this adds a one-element list
 list1.append([88])
 ```
-
+{: .language-python}
 ```
 [1, 2, 3, 4, 77, [88]]
 ```
@@ -245,7 +246,7 @@ And `.extend()` (combines two lists, instead of adding the second list as an ele
 ```python
 list1.extend([99, 88, 101])
 ```
-
+{: .language-python}
 ```
 [1, 2, 3, 4, 77, [88], 99, 88, 101]
 ```
@@ -259,7 +260,7 @@ print(list1)
 list1.clear()
 print(list1)
 ```
-
+{: .language-python}
 ```
 [1, 2, 3, 4, 77, 99, 88, 101]
 []
@@ -283,14 +284,14 @@ A for loop generally looks like the following:
 for variable in things_to_iterate_over:
 	do_stuff_with(variable)
 ```
-
+{: .language-python}
 An example of an actually functioning for loop is shown below:
 
 ```python
 for i in range(10):
 	print(i)
 ```
-
+{: .language-python}
 ```
 0
 1
@@ -315,7 +316,7 @@ We can also iterate over a list, or any collection of elements:
 for element in ['a', True, None]:
 	print(type(element))
 ```
-
+{: .language-python}
 ```
 <class 'str'>
 <class 'bool'>
@@ -342,7 +343,7 @@ for idx in range(1000):
 
 print(new_vals[:5])
 ```
-
+{: .language-python}
 ```
 [0, 1, 2, 3, 4]
 [10, 11, 12, 13, 14]
@@ -363,7 +364,7 @@ new_vals = np.array(vals)
 new_vals += 10
 new_vals[:5]
 ```
-
+{: .language-python}
 ```
 array([10, 11, 12, 13, 14])
 ```
@@ -380,7 +381,7 @@ Using Python's lists:
 for idx in range(1000):
 	vals[idx] + 10
 ```
-
+{: .language-python}
 ```
 10000 loops, best of 3: 165 µs per loop
 ```
@@ -390,7 +391,7 @@ Using numpy:
 ```python
 %timeit new_vals + 10
 ```
-
+{: .language-python}
 ```
 The slowest run took 22.13 times longer than the fastest. This could mean that an intermediate result is being cached.
 1000000 loops, best of 3: 1.63 µs per loop
@@ -409,7 +410,7 @@ arr2d = np.arange(0, 40)  # sequence of numbers from 0 to 39
 arr2d = arr2d.reshape([5, 8])  # reshape so it has 5 rows and 8 columns
 arr2d
 ```
-
+{: .language-python}
 ```
 array([[ 0,  1,  2,  3,  4,  5,  6,  7],
        [ 8,  9, 10, 11, 12, 13, 14, 15],
@@ -426,7 +427,7 @@ To grab the first element, we would use `[0, 0]`
 ```python
 arr2d[0, 0]
 ```
-
+{: .language-python}
 ```
 0
 ```
@@ -438,7 +439,7 @@ The first index, corresponds to rows, the second corresponds to columns, and the
 arr2d[0, :]
 arr2d[:, 0]
 ```
-
+{: .language-python}
 ```
 array([0, 1, 2, 3, 4, 5, 6, 7])
 array([ 0,  8, 16, 24, 32])

--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -285,6 +285,7 @@ for variable in things_to_iterate_over:
 	do_stuff_with(variable)
 ```
 {: .language-python}
+
 An example of an actually functioning for loop is shown below:
 
 ```python

--- a/_episodes/04-dicts.md
+++ b/_episodes/04-dicts.md
@@ -19,7 +19,7 @@ To create a dict, we use syntax like the following.
 example = {}
 type(example)
 ```
-
+{: .language-python}
 ```
 dict
 ```
@@ -33,7 +33,7 @@ and the stored data is referred to as the "value".
 example['key'] = 'value'
 example['key']
 ```
-
+{: .language-python}
 ```
 'value'
 ```
@@ -48,7 +48,7 @@ example[4] = False
 example['test'] = 5
 example[7] = 'myvalue'
 ```
-
+{: .language-python}
 
 To retrieve all keys in the dictionary, we can use the `.keys()`method.
 Note how we used the `list()` function to turn our resulting output into a list.
@@ -56,7 +56,7 @@ Note how we used the `list()` function to turn our resulting output into a list.
 ```python
 list(example.keys())
 ```
-
+{: .language-python}
 ```
 ['key', 1, 4, 'test', 7]
 ```
@@ -67,7 +67,7 @@ Likewise, we can retrieve all the values at once, using `.values()`
 ```python
 list(example.values())
 ```
-
+{: .language-python}
 ```
 ['value', 2, False, 5, 'myvalue']
 ```
@@ -83,7 +83,7 @@ list(example.values())
 >              'c': 3,
 >              'd': 4}
 > ```
-> 
+> {: .language-python}
 > ```
 > {'a': 1, 'b': 2, 'c': 3, 'd': 4}
 > ```

--- a/_episodes/05-functions.md
+++ b/_episodes/05-functions.md
@@ -54,6 +54,7 @@ adder(5)
 {: .output}
 
 > ## Practice defining functions
+>
 > Define a function that converts from temperatures in fahrenheit
 > to temperatures in kelvin, and another function that converts
 > back again.
@@ -303,6 +304,7 @@ list(filter(lambda x: x<3, [1,2,3,4,5]))
 {: .output}
 
 > ## Using lambdas in practice
+>
 > Add `'-cheesecake'` to every word in the following list using `map()`.
 > 
 > `['new york', 'chocalate', 'new york', 'ketchup', 'mayo']`
@@ -340,6 +342,7 @@ arr[arr >= 3]
 {: .language-python}
 
 > ## Removing np.nan values
+>
 > Remove all of the `np.nan` values from the following sequence
 > using logical indexing.
 > 

--- a/_episodes/05-functions.md
+++ b/_episodes/05-functions.md
@@ -21,7 +21,7 @@ def function(arg1):
     # do stuff with arg1
     return ans
 ```
-
+{: .language-python}
 
 So, an example function that adds two numbers together might look a little like this:
 
@@ -31,7 +31,7 @@ def adder(x, y):
 
 adder(1, 2)
 ```
-
+{: .language-python}
 ```
 3
 ```
@@ -47,7 +47,7 @@ def adder(x, y=10):
 
 adder(5)
 ```
-
+{: .language-python}
 ```
 15
 ```
@@ -75,7 +75,7 @@ True == True
 True == False
 'words' == 'words'
 ```
-
+{: .language-python}
 ```
 True
 False
@@ -89,7 +89,7 @@ True
 not True == False
 True != False
 ```
-
+{: .language-python}
 ```
 True
 True
@@ -105,7 +105,7 @@ Adding an equals sign (`>=`, `<=`) indicates less than or equal to or greater th
 -4 >= -4
 1 <= 2
 ```
-
+{: .language-python}
 ```
 True
 False
@@ -121,7 +121,7 @@ number = 5
 if number <= 10:
 	print('number was less than 10')
 ```
-
+{: .language-python}
 ```
 number was less than 10
 ```
@@ -135,7 +135,7 @@ number = 11
 if number <= 10:
 	print('number was less than 10')
 ```
-
+{: .language-python}
 
 However, we can add code to execute when the `if` condition is not met by adding an `else` statement.
 
@@ -146,7 +146,7 @@ if number <= 10:
 else:
 	print('number was greater than 10')
 ```
-
+{: .language-python}
 ```
 number was greater than 10
 ```
@@ -164,7 +164,7 @@ elif number == 10:
 else:
 	print('number was greater than 10')
 ```
-
+{: .language-python}
 
 One final note, to check if a value is equal to `None` in Python
 we must use `is None` and `is not None`.
@@ -174,7 +174,7 @@ Normal `==` operators will not work.
 None is None
 5 is not None
 ```
-
+{: .language-python}
 ```
 True
 True
@@ -187,6 +187,7 @@ Additionally, we can check if one value is in another set of values with the `in
 5 in [4, 5, 6]
 43 in [4, 5, 6]
 ```
+{: .language-python}
 ```
 True
 False
@@ -207,6 +208,7 @@ The syntax of map/reduce/filter is identical:
 ```python
 map(function, thing_to_iterate_over, next_thing_to_iterate_over)
 ```
+{: .language-python}
 
 Let's apply this to a few test cases using map. 
 Note that when selecting which function we are going to "map" with, 
@@ -216,7 +218,7 @@ import math
 values = [0, 1, 2, 3, 4, 5, 6]
 map(math.sin, values)
 ```
-
+{: .language-python}
 ```
 <map object at 0x7f31c246cba8>
 ```
@@ -227,7 +229,7 @@ To retrieve the actual values, we typically need to make the resulting output a 
 ```python
 list(map(math.sin, values))
 ```
-
+{: .language-python}
 ```
 [0.0,
  0.8414709848078965,
@@ -248,7 +250,7 @@ def less_than_3(val):
 
 list(filter(less_than_3, values))
 ```
-
+{: .language-python}
 ```
 [0, 1, 2]
 ```
@@ -264,7 +266,7 @@ To define a lambda function in python, the general syntax is as follows:
 ```python
 lambda x: x + 54
 ``` 
-
+{: .language-python}
 
 In this case, `lambda x:` indicates we are defining a lambda function with a single argument, `x`. 
 Everything following the `:` is our function.
@@ -275,14 +277,14 @@ So `lambda x: x + 54` equates to:
 def some_func(x):
 	return x + 54
 ```
-
+{: .language-python}
 
 Rewriting our filter statement to use a lambda function:
 
 ```python
 list(filter(lambda x: x < 3, values))
 ```
-
+{: .language-python}
 ```
 [0, 1, 2]
 ```
@@ -293,6 +295,7 @@ And a side-by-side example that demonstrates the difference between `map()` and 
 list(map(lambda x: x+100, [1,2,3,4,5]))
 list(filter(lambda x: x<3, [1,2,3,4,5]))
 ```
+{: .language-python}
 ```
 [101, 102, 103, 104, 105]   # map()
 [1, 2]   # filter()
@@ -320,7 +323,7 @@ vector_cube = np.vectorize(lambda x: x ** 3)
 
 vector_cube(np.array([1, 2, 3, 4, 5]))
 ```
-
+{: .language-python}
 ```
 array([  1,   8,  27,  64, 125])
 ```
@@ -334,7 +337,7 @@ when indexing a Numpy array.
 arr = np.array([1, 2, 3, 4, 5])
 arr[arr >= 3]
 ```
-
+{: .language-python}
 
 > ## Removing np.nan values
 > Remove all of the `np.nan` values from the following sequence

--- a/_episodes/06-parallel.md
+++ b/_episodes/06-parallel.md
@@ -47,7 +47,7 @@ The number of concurrent tasks that can be started at the same time, however is 
 Now imagine that all workers have to obtain their paint form a central dispenser located at the middle of the room. 
 If each worker is using a different colour, then they can work asynchronously. 
 However, if they use the same colour, and two of them run out of paint at the same time, 
-then they have to synchronize to use the dispenser - 
+then they have to synchronize to use the dispenser --
 one should wait while the other is being serviced.
 
 In our analogy, the paint dispenser represents access to the memory in your computer.
@@ -78,7 +78,7 @@ In this example, each painter would be a process (an individual instance of a pr
 The painters' arms represent a "thread" of a program.
 Threads are separate points of execution within a single program, and can be executed either synchronously or asynchronously.
 
-------------------------------------------------
+---
 
 ## How does parallelization work in practice?
 
@@ -113,13 +113,13 @@ We will cover basic shared-memory programming in Python using the `multiprocess`
 
 ### Distributed memory programming
 
-Shared memory programming, although very useful - has one major limitation:
+Shared memory programming, although very useful, has one major limitation:
 we can only use the number of CPU cores present on a single computer.
 If we want to increase speed a program runs any more, we need a better computer.
 Big computers cost lots and lots of money.
 Wouldn't it be more efficient to just use a lot of smaller, cheap computers instead?
 
-This is the rationale behind distributed memory programming- 
+This is the rationale behind distributed memory programming --
 a task is farmed out to a large number of computers, 
 each of which tackle an individual portion of a problem.
 Results are communicated back and forth between compute nodes.
@@ -170,7 +170,7 @@ import psutil
 # logical=True counts threads, but we are interested in cores
 psutil.cpu_count(logical=False)
 ```
-
+{: .language-python}
 ```
 8
 ```
@@ -223,6 +223,7 @@ AttributeError: Can't get attribute 'sleeping' on <module '__main__'>
 {: .error}
 
 > ## Differences between Jupyter notebooks versus and the Python/IPython interpreters
+>
 > The last command may have succeeded if you are running in a Python or IPython shell.
 > This is due to a difference in the way Jupyter executes user-defined functions):
 >

--- a/_episodes/06-parallel.md
+++ b/_episodes/06-parallel.md
@@ -182,7 +182,7 @@ Using this number, we can create a pool of worker processes withh which to paral
 from multiprocessing import Pool
 pool = Pool(psutil.cpu_count(logical=False))
 ```
-
+{: .language-python}
 
 The `pool` object gives us a set of parallel workers we can
 use to parallelize our calculations.
@@ -200,6 +200,7 @@ def sleeping(arg):
 
 %timeit list(map(sleeping, range(24)))
 ```
+{: .language-python}
 ```
 1 loop, best of 3: 2.4 s per loop
 ```
@@ -210,8 +211,10 @@ Now let's try it in parallel:
 ```python
 %timeit pool.map(sleeping, range(24))
 ```
+{: .language-python}
 
 If you are using a Jupyter notebook, this will fail:
+
 ```
 # more errors omitted
 AttributeError: Can't get attribute 'sleeping' on <module '__main__'>
@@ -236,6 +239,7 @@ AttributeError: Can't get attribute 'sleeping' on <module '__main__'>
 > ```python
 > pool.map(lambda x: time.sleep(0.1), range(24))
 > ```
+> {: .language-python}
 > ```
 > ---------------------------------------------------------------------------
 > PicklingError                             Traceback (most recent call last)
@@ -270,7 +274,7 @@ pool = Pool(8)
 %timeit pool.map(lambda x: time.sleep(0.1), range(24))
 pool.close()
 ```
-
+{: .language-python}
 ```
 1 loop, best of 3: 309 ms per loop
 ```
@@ -291,6 +295,7 @@ result2 = pool.map(another_function, more_stuff_to_iterate_over)
 # turn off your parallel workers at the end of your script
 pool.close()
 ```
+{: .language-python}
 
 Parallel workers (with their own copy of everything) are created, 
 data are sent to these workers, and then results are combined back together again.
@@ -299,5 +304,3 @@ that lets you control how big each chunk of data is before it's sent off to each
 A larger chunksize means that less time is spent shuttling data to and from workers,
 and will be more useful if you have a large number of very fast computations to perform.
 When each iteration takes a very long time to run, you will want to use a smaller chunk size.
-
-

--- a/_episodes/11-snakemake-intro.md
+++ b/_episodes/11-snakemake-intro.md
@@ -41,16 +41,16 @@ The first argument (`books/isles.txt`) to wordcount.py is the file to analyze,
 and the last argument (`isles.dat`) specifies the output file to write.
 
 ```bash
-python wordcount.py books/isles.txt isles.dat
+$ python wordcount.py books/isles.txt isles.dat
 ```
-
+{: .language-bash}
 
 Let's take a quick peek at the result.
 
 ```bash
-head -5 isles.dat
+$ head -5 isles.dat
 ```
-
+{: .language-bash}
 
 This shows us the top 5 lines in the output file:
 
@@ -71,11 +71,10 @@ number of words in the text file.
 We can do the same thing for a different book:
 
 ```bash
-python wordcount.py books/abyss.txt abyss.dat
-head -5 abyss.dat
+$ python wordcount.py books/abyss.txt abyss.dat
+$ head -5 abyss.dat
 ```
-
-
+{: .language-bash}
 ```
 the 4044 6.35449402891
 and 2807 4.41074795726
@@ -90,8 +89,9 @@ The script `plotcount.py` reads in a data file and plots the 10 most
 frequently occurring words as a text-based bar plot:
 
 ```bash
-python plotcount.py isles.dat ascii
+$ python plotcount.py isles.dat ascii
 ```
+{: .language-bash}
 ```
 the   ########################################################################
 of    ##############################################
@@ -109,9 +109,9 @@ it    ###########
 `plotcount.py` can also show the plot graphically:
 
 ```bash
-python plotcount.py isles.dat show
+$ python plotcount.py isles.dat show
 ```
-
+{: .language-bash}
 
 Close the window to exit the plot.
 
@@ -120,12 +120,14 @@ Close the window to exit the plot.
 ```bash
 python plotcount.py isles.dat isles.png
 ```
+{: .language-bash}
 
 Finally, let's test Zipf's law for these books:
 
 ```bash
-python zipf_test.py abyss.dat isles.dat
+$ python zipf_test.py abyss.dat isles.dat
 ```
+{: .language-bash}
 ```
 Book	First	Second	Ratio
 abyss	4044	2807	1.44
@@ -170,15 +172,15 @@ python plotcount.py abyss.dat abyss.png
 # Generate summary table
 python zipf_test.py abyss.dat isles.dat > results.txt
 ```
-
+{: .source}
 
 Run the script and check that the output is the same as before:
 
 ```bash
-bash run_pipeline.sh
-cat results.txt
+$ bash run_pipeline.sh
+$ cat results.txt
 ```
-
+{: .language-bash}
 
 This shell script solves several problems in computational reproducibility:
 
@@ -210,11 +212,9 @@ Alternatively, we could manually rerun the plotting for each word-count file.
 for-loop.)
 
 ```bash
-for book in abyss isles; do
-    python plotcount.py $book.dat $book.png
-done
+$ for book in abyss isles; do python plotcount.py $book.dat $book.png; done
 ```
-
+{: .language-bash}
 
 With this approach, however,
 we don't get many of the benefits of having a shell script in the first place.
@@ -237,6 +237,7 @@ python plotcount.py abyss.dat abyss.png
 # This line is also commented out because it doesn't need to be rerun.
 python zipf_test.py abyss.dat isles.dat > results.txt
 ```
+{: .source}
 
 Then, we would run our modified shell script using `bash run_pipeline.sh`.
 
@@ -271,4 +272,3 @@ There are several reasons this tool was chosen:
 The rest of these lessons aim to teach you how to use Snakemake by example. 
 Our goal is to automate our example workflow, and have it do everything for us in parallel
 regardless of where and how it is run (and have it be reproducible!).
-

--- a/_episodes/11-snakemake-intro.md
+++ b/_episodes/11-snakemake-intro.md
@@ -118,7 +118,7 @@ Close the window to exit the plot.
 `plotcount.py` can also create the plot as an image file (e.g. a PNG file):
 
 ```bash
-python plotcount.py isles.dat isles.png
+$ python plotcount.py isles.dat isles.png
 ```
 {: .language-bash}
 
@@ -172,7 +172,7 @@ python plotcount.py abyss.dat abyss.png
 # Generate summary table
 python zipf_test.py abyss.dat isles.dat > results.txt
 ```
-{: .source}
+{: .language-bash}
 
 Run the script and check that the output is the same as before:
 
@@ -237,7 +237,7 @@ python plotcount.py abyss.dat abyss.png
 # This line is also commented out because it doesn't need to be rerun.
 python zipf_test.py abyss.dat isles.dat > results.txt
 ```
-{: .source}
+{: .language-bash}
 
 Then, we would run our modified shell script using `bash run_pipeline.sh`.
 

--- a/_episodes/12-snakefiles.md
+++ b/_episodes/12-snakefiles.md
@@ -22,7 +22,7 @@ rule count_words:
     output: 'isles.dat'
     shell: 'python wordcount.py books/isles.txt isles.dat'
 ```
-
+{: .language-python}
 
 This is a [build file]({{ page.root }}/reference/#build-file), which for
 Snakemake is called a [Snakefile]({{ page.root }}/reference/#makefile) - a file executed
@@ -57,16 +57,17 @@ Let's first ensure we start from scratch and delete the `.dat` and `.png`
 files we created earlier:
 
 ```bash
-rm *.dat *.png
+$ rm *.dat *.png
 ```
-
+{: .language-bash}
 
 By default, Snakemake looks for a file called `Snakefile`, and we can
 run Snakemake as follows:
 
 ```bash
-snakemake
+$ snakemake
 ```
+{: .language-bash}
 
 By default, Snakemake tells us what it's doing as it executes actions:
 
@@ -94,9 +95,9 @@ Snakemake follows Python syntax.
 Let's see if we got what we expected:
 
 ```bash
-head -5 isles.dat
+$ head -5 isles.dat
 ```
-
+{: .language-bash}
 
 The first 5 lines of `isles.dat` should look exactly like before.
 
@@ -107,8 +108,9 @@ The first 5 lines of `isles.dat` should look exactly like before.
 > using `-s` flag. For example, if our Makefile is named `MyOtherSnakefile`:
 >
 > ```bash
-> snakemake -s MyOtherMakefile
+> $ snakemake -s MyOtherMakefile
 > ```
+> {: .language-bash}
 > 
 {: .callout}
 
@@ -126,15 +128,16 @@ editor, we can use the shell `touch` command to update its timestamp
 (which would happen if we did edit the file):
 
 ```bash
-touch books/isles.txt
+$ touch books/isles.txt
 ```
-
+{: .language-bash}
 
 If we compare the timestamps of `books/isles.txt` and `isles.dat`,
 
 ```bash
-ls -l books/isles.txt isles.dat
+$ ls -l books/isles.txt isles.dat
 ```
+{: .language-bash}
 
 then we see that `isles.dat`, the target, is now older
 than`books/isles.txt`, its dependency:
@@ -148,8 +151,9 @@ than`books/isles.txt`, its dependency:
 If we run Make again,
 
 ```bash
-snakemake
+$ snakemake
 ```
+{: .language-bash}
 
 then it recreates `isles.dat`:
 
@@ -196,13 +200,14 @@ rule count_words_abyss:
 	output: 'abyss.dat'
 	shell: 	'python wordcount.py books/abyss.txt abyss.dat'
 ```
-
+{: .language-python}
 
 If we run Snakemake,
 
 ```bash
-snakemake
+$ snakemake
 ```
+{: .language-bash}
 
 then we get:
 
@@ -218,8 +223,9 @@ already up-to-date. We need to explicitly tell Make we want to build
 `abyss.dat`:
 
 ```bash
-snakemake abyss.dat
+$ snakemake abyss.dat
 ```
+{: .language-bash}
 
 Now, we get:
 
@@ -255,10 +261,9 @@ Finished job 0.
 > no rule in our Snakefile, then we get message like:
 >
 > ```bash
-> snakemake wordcount.py
+> $ snakemake wordcount.py
 > ```
-> 
->
+> {: .language-bash} 
 > ```
 > MissingRuleException:
 > No rule to produce wordcount.py (if you use input functions make sure that they don't raise unexpected exceptions).
@@ -269,7 +274,6 @@ Finished job 0.
 > Even a small difference in a filename will result in a MissingRuleException.
 {: .callout}
 
-
 We may want to remove all our data files so we can explicitly recreate
 them all. We can introduce a new target, and associated rule, to do
 this. We will call it `clean`, as this is a common name for rules that
@@ -279,14 +283,15 @@ delete auto-generated files, like our `.dat` files:
 rule clean:
     shell: 'rm -f *.dat'
 ```
+{: .language-python}
 
 This is an example of a rule that has no inputs or outputs!. We just want to remove the data files whether or
 not they exist. If we run Make and specify this target,
 
 ```bash
-snakemake clean
+$ snakemake clean
 ```
-
+{: .language-bash}
 
 then we get:
 
@@ -319,7 +324,7 @@ rule dats:
          'isles.dat',
          'abyss.dat'
 ```
-
+{: .language-python}
 
 This is an example of a rule that has dependencies that are targets of
 other rules. When Make runs, it will check to see if the dependencies
@@ -344,9 +349,9 @@ purely to trigger the build of its dependencies, if needed.
 If we run,
 
 ```bash
-snakemake dats
+$ snakemake dats
 ```
-
+{: .language-bash}
 
 then snakemake creates the data files:
 
@@ -390,14 +395,13 @@ and abyss.dat) are already up to date.
 Given the target `dats` has no actions, there is `nothing to be done`:
 
 ```bash
-snakemake dats
+$ snakemake dats
 ```
-
+{: .language-bash}
 ```
 Nothing to be done
 ```
 {: .output}
-
 
 Our Snakefile now looks like this:
 
@@ -425,7 +429,7 @@ rule count_words_abyss:
     output: 'abyss.dat'
     shell: 	'python wordcount.py books/abyss.txt abyss.dat'
 ```
-
+{: .language-python}
 
 The following figure shows a graph of the dependencies embodied within
 our Makefile, involved in building the `dats` target:
@@ -440,10 +444,10 @@ A dry run does nothing, and simply prints out commands instead of actually execu
 Very useful for debugging!
 
 ```bash
-snakemake clean
-snakemake -n -p isles.dat
+$ snakemake clean
+$ snakemake -n -p isles.dat
 ```
-
+{: .language-bash}
 ```
 rule count_words:
     input: wordcount.py, books/isles.txt

--- a/_episodes/12-snakefiles.md
+++ b/_episodes/12-snakefiles.md
@@ -194,13 +194,13 @@ Let's add another rule to the end of `Snakefile`.
 Note that rules cannot have the same name, 
 so we'll call this one `count_words_abyss`.
 
-```python
+```make
 rule count_words_abyss:
 	input: 	'books/abyss.txt'
 	output: 'abyss.dat'
 	shell: 	'python wordcount.py books/abyss.txt abyss.dat'
 ```
-{: .language-python}
+{: .language-make}
 
 If we run Snakemake,
 
@@ -279,11 +279,11 @@ them all. We can introduce a new target, and associated rule, to do
 this. We will call it `clean`, as this is a common name for rules that
 delete auto-generated files, like our `.dat` files:
 
-```python
+```make
 rule clean:
     shell: 'rm -f *.dat'
 ```
-{: .language-python}
+{: .language-make}
 
 This is an example of a rule that has no inputs or outputs!. We just want to remove the data files whether or
 not they exist. If we run Make and specify this target,
@@ -318,13 +318,13 @@ this at the top of our Snakefile so that it is the [default
 target]({{ page.root }}/reference/#default-target), which is executed by default
 if no target is given to the `snakemake` command:
 
-```python
+```make
 rule dats:
      input:
          'isles.dat',
          'abyss.dat'
 ```
-{: .language-python}
+{: .language-make}
 
 This is an example of a rule that has dependencies that are targets of
 other rules. When Make runs, it will check to see if the dependencies
@@ -405,7 +405,7 @@ Nothing to be done
 
 Our Snakefile now looks like this:
 
-```python
+```make
 rule dats:
      input:
          'isles.dat',
@@ -429,7 +429,7 @@ rule count_words_abyss:
     output: 'abyss.dat'
     shell: 	'python wordcount.py books/abyss.txt abyss.dat'
 ```
-{: .language-python}
+{: .language-make}
 
 The following figure shows a graph of the dependencies embodied within
 our Makefile, involved in building the `dats` target:

--- a/_episodes/13-wildcards.md
+++ b/_episodes/13-wildcards.md
@@ -16,7 +16,7 @@ keypoints:
 
 After the exercise at the end of the previous episode, our Snakefile looked like this:
 
-```python
+```make
 # generate summary table
 rule zipf_test:
     input:  'abyss.dat', 'last.dat', 'isles.dat'
@@ -46,7 +46,7 @@ rule count_words_last:
     output: 'last.dat'
     shell: 	'python wordcount.py books/last.txt last.dat'
 ```
-{: .language-python}
+{: .language-make}
 
 Our Snakefile has a lot of duplication. For example, the names of text
 files and data files are repeated in many places throughout the
@@ -70,7 +70,7 @@ Let us set about removing some of the repetition from our Snakefile.
 In our `zip_test` rule we duplicate the data file names and the
 name of the results file name:
 
-```python
+```make
 rule zipf_test:
     input:
             'abyss.dat',
@@ -79,31 +79,31 @@ rule zipf_test:
     output: 'results.txt'
     shell:  'python zipf_test.py abyss.dat isles.dat last.dat > results.txt'
 ```
-{: .language-python}
+{: .language-make}
 
 Looking at the results file name first, we can replace it in the action
 with `{output}`:
 
-```python
+```make
 rule zipf_test:
     input:  'abyss.dat', 'last.dat', 'isles.dat'
     output: 'results.txt'
     shell:  'python zipf_test.py abyss.dat isles.dat last.dat > {output}'
 ```
-{: .language-python}
+{: .language-make}
 
 `{output}` is a Snakemake [wildcard]({{ page.root }}/reference/#automatic-variable)
 which is equivalent to the value we specified for {output}. 
 
 We can replace the dependencies in the action with `{input}`:
 
-```python
+```make
 rule zipf_test:
     input:  'abyss.dat', 'last.dat', 'isles.dat'
     output: 'results.txt'
     shell:  'python zipf_test.py {input} > {output}'
 ```
-{: .language-python}
+{: .language-make}
 
 `{input}` is another wildcard which means 'all the dependencies
 of the current rule'. Again, when Make is run it will replace this
@@ -112,8 +112,8 @@ variable with the dependencies.
 Let's update our text files and re-run our rule:
 
 ```bash
-> touch books/*.txt
-> snakemake results.txt
+$ touch books/*.txt
+$ snakemake results.txt
 ```
 {: .language-bash}
 
@@ -223,17 +223,17 @@ We need to add `wordcount.py` as a dependency of each of our data files.
 In this case, we can use `{input[0]}` to refer to the first dependency, 
 and `{input[1]}` to refer to the second.
 
-```python
+```make
 rule count_words:
     input: 	'wordcount.py', 'books/isles.txt'
     output: 'isles.dat'
     shell: 	'python {input[0]} {input[1]} {output}'
 ```
-{: .language-python}
+{: .language-make}
 
 Alternatively, we can name our dependencies.
 
-```python
+```make
 rule count_words_abyss:
     input: 	
         wc='wordcount.py',
@@ -241,7 +241,7 @@ rule count_words_abyss:
     output: 'abyss.dat'
     shell: 	'python {input.wc} {input.book} {output}'
 ```
-{: .language-python}
+{: .language-make}
 
 Let's mark `wordcount.py` as updated, and re-run the pipeline.
 

--- a/_episodes/13-wildcards.md
+++ b/_episodes/13-wildcards.md
@@ -46,7 +46,7 @@ rule count_words_last:
     output: 'last.dat'
     shell: 	'python wordcount.py books/last.txt last.dat'
 ```
-
+{: .language-python}
 
 Our Snakefile has a lot of duplication. For example, the names of text
 files and data files are repeated in many places throughout the
@@ -79,6 +79,7 @@ rule zipf_test:
     output: 'results.txt'
     shell:  'python zipf_test.py abyss.dat isles.dat last.dat > results.txt'
 ```
+{: .language-python}
 
 Looking at the results file name first, we can replace it in the action
 with `{output}`:
@@ -89,6 +90,7 @@ rule zipf_test:
     output: 'results.txt'
     shell:  'python zipf_test.py abyss.dat isles.dat last.dat > {output}'
 ```
+{: .language-python}
 
 `{output}` is a Snakemake [wildcard]({{ page.root }}/reference/#automatic-variable)
 which is equivalent to the value we specified for {output}. 
@@ -101,6 +103,7 @@ rule zipf_test:
     output: 'results.txt'
     shell:  'python zipf_test.py {input} > {output}'
 ```
+{: .language-python}
 
 `{input}` is another wildcard which means 'all the dependencies
 of the current rule'. Again, when Make is run it will replace this
@@ -109,9 +112,10 @@ variable with the dependencies.
 Let's update our text files and re-run our rule:
 
 ```bash
-touch books/*.txt
-snakemake results.txt
+> touch books/*.txt
+> snakemake results.txt
 ```
+{: .language-bash}
 
 We get:
 
@@ -166,10 +170,10 @@ Finished job 0.
 > What will happen if you now execute:
 >
 > ```bash
-> touch *.dat
-> snakemake results.txt
+> $ touch *.dat
+> $ snakemake results.txt
 > ```
-> 
+> {: .language-bash}
 >
 > 1. nothing
 > 2. all files recreated
@@ -185,10 +189,10 @@ Finished job 0.
 > > If you run:
 > >
 > > ```bash
-> > touch books/*.txt
-> > snakemake results.txt
+> > $ touch books/*.txt
+> > $ snakemake results.txt
 > > ```
-> > 
+> > {: .language-bash}
 > >
 > > you will find that the `.dat` files as well as `results.txt` are recreated.
 > {: .solution}
@@ -225,6 +229,7 @@ rule count_words:
     output: 'isles.dat'
     shell: 	'python {input[0]} {input[1]} {output}'
 ```
+{: .language-python}
 
 Alternatively, we can name our dependencies.
 
@@ -236,14 +241,15 @@ rule count_words_abyss:
     output: 'abyss.dat'
     shell: 	'python {input.wc} {input.book} {output}'
 ```
-
+{: .language-python}
 
 Let's mark `wordcount.py` as updated, and re-run the pipeline.
 
 ```bash
-touch wordcount.py
-snakemake
+$ touch wordcount.py
+$ snakemake
 ```
+{: .language-bash}
 
 ```
 Provided cores: 1
@@ -288,10 +294,10 @@ Intuitively, we should also add `wordcount.py` as dependency for
 happens to `results.txt` when we update `wordcount.py`:
 
 ```bash
-touch wordcount.py
-snakemake results.txt
+$ touch wordcount.py
+$ snakemake results.txt
 ```
-
+{: .language-bash}
 
 then we get:
 
@@ -346,10 +352,10 @@ downstream steps.
 > What will happen if you now execute:
 >
 > ```bash
-> touch books/last.txt
-> make results.txt
+> $ touch books/last.txt
+> $ make results.txt
 > ```
-> 
+> {: .language-bash}
 >
 > 1. only `last.dat` is recreated
 > 2. all `.dat` files are recreated

--- a/_episodes/14-patterns.md
+++ b/_episodes/14-patterns.md
@@ -16,7 +16,7 @@ replace these rules with a single [pattern
 rule]({{ page.root }}/reference/#pattern-rule) which can be used to build any
 `.dat` file from a `.txt` file in `books/`:
 
-```python
+```make
 rule count_words:
     input: 	
         wc='wordcount.py',
@@ -24,7 +24,7 @@ rule count_words:
     output: '{file}.dat'
     shell: 	'python {input.wc} {input.book} {output}'
 ```
-{: .language-python}
+{: .language-make}
 
 `{file}` is another arbitrary [wildcard]({{ page.root }}/reference/#wildcard),
 that we can use as a placeholder for any generic book to analyze.
@@ -82,7 +82,7 @@ Finished job 0.
 
 Our Snakefile is now much shorter and cleaner:
 
-```python
+```make
 # generate summary table
 rule zipf_test:
     input:  'zipf_test.py', 'abyss.dat', 'last.dat', 'isles.dat'
@@ -105,4 +105,4 @@ rule count_words:
     output: '{file}.dat'
     shell: 	'python {input.wc} {input.book} {output}'
 ```
-{: .language-python}
+{: .language-make}

--- a/_episodes/14-patterns.md
+++ b/_episodes/14-patterns.md
@@ -24,7 +24,7 @@ rule count_words:
     output: '{file}.dat'
     shell: 	'python {input.wc} {input.book} {output}'
 ```
-
+{: .language-python}
 
 `{file}` is another arbitrary [wildcard]({{ page.root }}/reference/#wildcard),
 that we can use as a placeholder for any generic book to analyze.
@@ -37,19 +37,20 @@ find a file named `books/[that same something].txt` (the dependency)
 and run `wordcount.py [the dependency] [the target]`."
 
 ```bash
-snakemake clean
+$ snakemake clean
 # use the -p option to show that it is running things correctly!
-snakemake -p dats   
+$ snakemake -p dats
 ```
+{: .language-bash}
 
 We should see the same output as before.
 Note that we can still use snakemake to build individual `.dat` targets as before,
 and that our new rule will work no matter what stem is being matched.
 
 ```bash
-snakemake -p sierra.dat
+$ snakemake -p sierra.dat
 ```
-
+{: .language-bash}
 
 which gives the output below:
 
@@ -104,4 +105,4 @@ rule count_words:
     output: '{file}.dat'
     shell: 	'python {input.wc} {input.book} {output}'
 ```
-
+{: .language-python}

--- a/_episodes/15-snakemake-python.md
+++ b/_episodes/15-snakemake-python.md
@@ -26,7 +26,7 @@ rule zipf_test:
     output: 'results.txt'
     shell:  'python {input[0]} {input[1]} {input[2]} {input[3]} > {output}'
 ```
-
+{: .language-make}
 
 First, let's cut down on a little bit of the clunkiness of the "shell" rule.
 One thing you've probably noticed is that all of our rules are using Python strings.
@@ -40,6 +40,7 @@ rule zipf_test:
     output: 'results.txt'
     shell:  'python {input.zipf} {input.books} > {output}'
 ```
+{: .language-make}
 
 (`snakemake clean` and `snakemake -p` should show that the pipeline still works!)
 
@@ -53,7 +54,7 @@ DATS=['abyss.dat', 'last.dat', 'isles.dat']
 
 # generate summary table
 rule zipf_test:
-    input:  
+    input:
         zipf='zipf_test.py',
         books=DATS
     output: 'results.txt'
@@ -62,7 +63,7 @@ rule zipf_test:
 rule dats:
     input: DATS
 ```
-
+{: .language-make}
 
 Try re-creating both the `dats` and `results.txt` targets
 (run `snakemake clean` in between).
@@ -83,14 +84,14 @@ rule zipf_test:
     input:  
 # more output below
 ```
-
+{: .language-make}
 
 Now let's clean up our workspace with `snakemake clean`
 
 ```bash
 snakemake clean
 ```
-
+{: .language-bash}
 ```
 Snakefile is being executed!
 Provided cores: 1
@@ -111,9 +112,9 @@ Finished job 0.
 Now let's re-run the pipeline...
 
 ```bash
-snakemake
+$ snakemake
 ```
-
+{: .language-bash}
 ```
 Snakefile is being executed!
 Provided cores: 1
@@ -164,9 +165,9 @@ Finished job 0.
 Let's do a dry-run:
 
 ```bash
-snakemake -n
+$ snakemake -n
 ```
-
+{: .language-bash}
 ```
 Snakefile is being executed!
 Nothing to be done.
@@ -193,9 +194,9 @@ The two most helpful ones are `glob_wildcards()` and `expand()`.
 Let's start an ipython session to see how they work:
 
 ```bash
-ipython3
+$ ipython3
 ```
-
+{: .language-bash}
 ```
 Python 3.6.1 (default, Jun 27 2017, 14:35:15) 
 Type "copyright", "credits" or "license" for more information.
@@ -215,7 +216,7 @@ these functions are always imported for you.
 ```python
 from snakemake.io import *
 ```
-
+{: .language-python}
 
 ### Generating file names with expand()
 
@@ -226,7 +227,7 @@ to expand a snakemake wildcard(s) into a set of filenames.
 ```python
 expand('folder/{wildcard1}_{wildcard2}.txt', wildcard1=['a', 'b', 'c'], wildcard2=[1, 2, 3])
 ```
-
+{: .language-python}
 ```
 ['folder/a_1.txt',
  'folder/a_2.txt',
@@ -253,7 +254,7 @@ Let's try grabbing all of the book titles in our `books` folder.
 ```python
 glob_wildcards('books/{example}.txt')
 ```
-
+{: .language-python}
 ```
 Wildcards(example=['isles', 'last', 'abyss', 'sierra'])
 ```
@@ -267,7 +268,7 @@ property from the output of `glob_wildcards()`
 ```python
 glob_wildcards('books/{example}.txt').example
 ```
-
+{: .language-python}
 ```
 ['isles', 'last', 'abyss', 'sierra']
 ```
@@ -300,15 +301,15 @@ rule print_book_names:
         for book in glob.glob('books/*.txt'):
             print(book)
 ```
-
+{: .language-python}
 
 Upon execution of the corresponding rule, Snakemake dutifully runs our Python code
 in the `run:` block:
 
 ```bash
-snakemake print_book_names
+$ snakemake print_book_names
 ```
-
+{: .language-bash}
 ```
 Provided cores: 1
 Rules claiming more threads will be scaled down.
@@ -369,7 +370,7 @@ Finished job 0.
 > ```bash
 > tar -czvf zipf_analysis.tar.gz file1 directory2 file3 etc
 > ```
-> 
+> {: .language-bash}
 {: .challenge}
 
 After these excercises our final workflow should look something like the following:
@@ -393,4 +394,3 @@ After these excercises our final workflow should look something like the followi
 > * run `snakemake` and check that the correct commands are run
 > * check the results.txt file to see how this book compares to the others
 {: .challenge}
-

--- a/_episodes/15-snakemake-python.md
+++ b/_episodes/15-snakemake-python.md
@@ -20,7 +20,7 @@ Our `zipf_test` rule, for instance, is extremely clunky.
 What happens if we want to analyze `books/sierra.txt` as well?
 We'd have to update everything!
 
-```python
+```make
 rule zipf_test:
     input:  'zipf_test.py', 'abyss.dat', 'last.dat', 'isles.dat'
     output: 'results.txt'
@@ -32,7 +32,7 @@ First, let's cut down on a little bit of the clunkiness of the "shell" rule.
 One thing you've probably noticed is that all of our rules are using Python strings.
 Other data structures work too - let's try a list:
 
-```python
+```make
 rule zipf_test:
     input:  
         zipf='zipf_test.py',
@@ -47,9 +47,9 @@ rule zipf_test:
 This illustrates a key feature of Snakemake. 
 Snakefiles are just Python code.
 We can make our list into a variable to demonstrate this. 
-Let's create the variable DATS and use it in our `zipf_test` and `dats` rules.
+Let's create the variable `DATS` and use it in our `zipf_test` and `dats` rules.
 
-```python
+```make
 DATS=['abyss.dat', 'last.dat', 'isles.dat']
 
 # generate summary table
@@ -74,14 +74,14 @@ The last example illustrated that we can use arbitrary Python code in our Snakef
 It's important to understand when this code gets executed.
 Let's add a print statement to the top of our Snakefile.
 
-```python
+```make
 print('Snakefile is being executed!')
 
 DATS=['abyss.dat', 'last.dat', 'isles.dat']
 
 # generate summary table
 rule zipf_test:
-    input:  
+    input:
 # more output below
 ```
 {: .language-make}

--- a/_episodes/16-resources.md
+++ b/_episodes/16-resources.md
@@ -26,7 +26,7 @@ rule all:
 
 # delete everything so we can re-run things
 rule clean:
-    shell:  
+    shell:
         '''
         rm -rf results dats plots
         rm -f results.txt zipf_analysis.tar.gz
@@ -50,7 +50,7 @@ rule make_plot:
 
 # generate summary table
 rule zipf_test:
-    input:  
+    input:
         zipf='zipf_test.py',
         books=expand('dats/{book}.dat', book=DATS)
     output: 'results.txt'
@@ -65,7 +65,7 @@ rule make_archive:
     output: 'zipf_analysis.tar.gz'
     shell: 'tar -czvf {output} {input}'
 ```
-
+{: .language-make}
 
 At this point, we have a complete data analysis pipeline.
 Very cool.
@@ -89,10 +89,10 @@ The only change we need to make is run Snakemake with the `-j` argument.
 and on a cluster, maximum number of jobs (we'll get to that part later).
 
 ```bash
-snakemake clean
-snakemake -j 4    # 4 cores is usually a safe assumption when working on a laptop/desktop
+$ snakemake clean
+$ snakemake -j 4    # 4 cores is usually a safe assumption when working on a laptop/desktop
 ```
-
+{: .language-bash}
 ```
 Provided cores: 4
 Rules claiming more threads will be scaled down.
@@ -121,7 +121,7 @@ serial pipeline is run `snakemake` with the `-j` option.
 > import psutil
 > psutil.cpu_count(logical=False)
 > ```
-> 
+> {: .language-python}
 {: .callout}
 
 ## Managing CPUs
@@ -155,7 +155,7 @@ rule count_words:
         python {input.wc} {input.book} {output}
         '''
 ```
-
+{: .language-make}
 
 Now, when we run `snakemake -j 4`, the `count_words` rules are run one at a time,
 so as to give each execution the resources it needs.
@@ -187,15 +187,15 @@ Finished job 3.
 
 # other output follows
 ```
-
+{: .output}
 
 What happens when we don't have 4 cores available?
 What if we tell Snakemake to run with 2 cores instead?
 
 ```bash
-snakemake -j 2
+$ snakemake -j 2
 ```
-
+{: .language-bash}
 ```
 Provided cores: 2
 Rules claiming more threads will be scaled down.
@@ -256,8 +256,7 @@ rule count_words:
             python {input.wc} {input.book} {output}
         '''
 ```
-
-
+{: .language-make}
 
 ## Managing other types of resources
 
@@ -283,15 +282,15 @@ rule make_plot:
     resources: gpu=1
     shell:  'python {input.plotcount} {input.book} {output}'
 ```
-
+{: .language-make}
 
 We can execute our pipeline using the following (using 8 cores and 1 gpu):
 
 ```bash
-snakemake clean
-snakemake -j 8 --resources gpu=1
+$ snakemake clean
+$ snakemake -j 8 --resources gpu=1
 ```
-
+{: .language-bash}
 ```
 Provided cores: 8
 Rules claiming more threads will be scaled down.
@@ -311,10 +310,10 @@ it is an arbitrary limit used to prevent multiple tasks that use a `gpu` from ex
 But what happens if we run our pipeline without specifying the number of GPUs?
 
 ```bash
-snakemake clean
-snakemake -j 8
+$ snakemake clean
+$ snakemake -j 8
 ```
-
+{: .language-bash}
 ```
 Provided cores: 8
 Rules claiming more threads will be scaled down.

--- a/_episodes/16-resources.md
+++ b/_episodes/16-resources.md
@@ -16,7 +16,7 @@ keypoints:
 After the excercises at the end of our last lesson, 
 our Snakefile looks something like this:
 
-```python
+```make
 # our zipf analysis pipeline
 DATS = glob_wildcards('books/{book}.txt').book
 
@@ -142,7 +142,7 @@ In this case `wordcount.py` is actually still running with 1 core,
 we are simply using it as a demonstration of how to go about 
 running something with multiple cores.
 
-```python
+```make
 rule count_words:
     input: 	
         wc='wordcount.py',
@@ -242,7 +242,7 @@ If the first command fails, the remaining steps are not run.
 This is more forgiving than bash's default "hit an error and keep going" behavior.
 After all, if the first command failed, it's unlikely the other steps will work.
 
-```python
+```make
 # count words in one of our "books"
 rule count_words:
     input: 	
@@ -272,7 +272,7 @@ How do we indicate this to Snakemake so that it knows to give dedicated access t
 for rules that need it?
 Let's modify the `make_plot` rule as an example:
 
-```python
+```make
 # create a plot for each book
 rule make_plot:
     input:

--- a/_episodes/17-cluster.md
+++ b/_episodes/17-cluster.md
@@ -57,7 +57,7 @@ rule all:
 
 # delete everything so we can re-run things
 rule clean:
-    shell:  
+    shell:
         '''
         rm -rf results dats plots
         rm -f results.txt zipf_analysis.tar.gz
@@ -86,7 +86,7 @@ rule make_plot:
 
 # generate summary table
 rule zipf_test:
-    input:  
+    input:
         zipf='zipf_test.py',
         books=expand('dats/{book}.dat', book=DATS)
     output: 'results.txt'
@@ -101,7 +101,7 @@ rule make_archive:
     output: 'zipf_analysis.tar.gz'
     shell: 'tar -czvf {output} {input}'
 ```
-
+{: .language-make}
 
 To run Snakemake on a cluster, we need to tell it how it to submit jobs.
 This is done using the `--cluster` argument.
@@ -119,13 +119,14 @@ Snakemake has a powerful archiving utility that we can use to bundle up our work
 
 
 ```bash
-snakemake clean
-tar -czvf pipeline.tar.gz .
+$ snakemake clean
+$ tar -czvf pipeline.tar.gz .
 # transfer the pipeline via scp
-scp pipeline.tar.gz yourUsername@graham.computecanada.ca:
+$ scp pipeline.tar.gz yourUsername@graham.computecanada.ca:
 # log on to the cluster
-ssh -X yourUsername@graham.computecanada.ca
+$ ssh -X yourUsername@graham.computecanada.ca
 ```
+{: .language-bash}
 
 > ## `snakemake --archive` and Conda deployment
 > 
@@ -146,23 +147,25 @@ At this point we've archived our entire pipeline, sent it to the cluster, and lo
 Let's create a folder for our pipeline and unpack it there.
 
 ```bash
-mkdir pipeline
-mv pipeline.tar.gz pipeline
-cd pipeline
-tar -xvzf pipeline.tar.gz
+$ mkdir pipeline
+$ mv pipeline.tar.gz pipeline
+$ cd pipeline
+$ tar -xvzf pipeline.tar.gz
 ```
+{: .language-bash}
 
 If Snakemake and Python are not already installed on your cluster, 
 you can install them using the following commands:
 
 ```bash
-wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-bash Miniconda3-latest-Linux-x86_64.sh -b
-echo 'export PATH=~/miniconda3/bin:~/.local/bin:$PATH' >> ~/.bashrc
-source ~/.bashrc
-conda install -y matplotlib numpy graphviz
-pip install --user snakemake
+$ wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+$ bash Miniconda3-latest-Linux-x86_64.sh -b
+$ echo 'export PATH=~/miniconda3/bin:~/.local/bin:$PATH' >> ~/.bashrc
+$ source ~/.bashrc
+$ conda install -y matplotlib numpy graphviz
+$ pip install --user snakemake
 ```
+{: .language-bash}
 
 Assuming you've transferred your files and everything is set to go, 
 the command `snakemake -n` should work without errors.
@@ -174,7 +177,7 @@ An example (using SLURM) is shown below.
 You can check to see if your `cluster.json` is valid JSON syntax by pasting its contents into
 the box at [jsonlint.com](https://jsonlint.com).
 
-```
+```json
 {
     "__default__":
     {
@@ -189,6 +192,7 @@ the box at [jsonlint.com](https://jsonlint.com).
     }
 }
 ```
+{: .source}
 
 This file has several components. 
 The values under `__default__` represents a set of default configuration values
@@ -210,10 +214,10 @@ It would be a better idea to have these rules execute locally
 instead of as a job.
 Let's define `all`, `clean`, and `make_archive` as localrules near the top of our `Snakefile`.
 
-```
+```make
 localrules: all, clean, make_archive
 ```
-
+{: .language-make}
 
 ## Running our workflow on the cluster
 
@@ -221,9 +225,9 @@ Ok, time for the moment we've all been waiting for - let's run our workflow on t
 To run our Snakefile, we'll run the following command:
 
 ```bash
-snakemake -j 100 --cluster-config cluster.json --cluster "sbatch -A {cluster.account} --mem={cluster.mem} -t {cluster.time} -c {threads}"
+$ snakemake -j 100 --cluster-config cluster.json --cluster "sbatch -A {cluster.account} --mem={cluster.mem} -t {cluster.time} -c {threads}"
 ```
-
+{: .language-bash}
 
 While things execute, you may wish to SSH to the cluster in another window so you can watch the pipeline's progress
 with `watch squeue -u $(whoami)`.

--- a/_episodes/17-cluster.md
+++ b/_episodes/17-cluster.md
@@ -47,7 +47,7 @@ is executed with the resources it needs.
 We'll explore how to port our example Snakemake pipeline by example 
 Our current Snakefile is shown below:
 
-```python
+```make
 # our zipf analysis pipeline
 DATS = glob_wildcards('books/{book}.txt').book
 

--- a/_episodes/18-final-notes.md
+++ b/_episodes/18-final-notes.md
@@ -58,14 +58,14 @@ rule count_words:
         python {input.wc} {input.book} {output} &>> {log}
         '''
 ```
-
+{: .language-make}
 
 ```bash
-snakemake clean
-snakemake -j 8
-cat dats/abyss.log
+$ snakemake clean
+$ snakemake -j 8
+$ cat dats/abyss.log
 ```
-
+{: .language-bash}
 ```
 # snakemake output omitted
 Running wordcount.py with 4 cores on books/abyss.txt.
@@ -102,7 +102,7 @@ rule token_example:
             touch {output}
         '''
 ```
-
+{: .language-make}
 
 ## Directory locks
 
@@ -131,9 +131,10 @@ which you can view using any picture viewing program.
 In fact this was the tool used to create all of the diagrams in this lesson:
 
 ```bash
-snakemake --dag | dot -Tsvg > dag.svg
-eog dag.svg     # eog is an image viewer installed on many linux systems
+$ snakemake --dag | dot -Tsvg > dag.svg
+$ eog dag.svg     # eog is an image viewer installed on many linux systems
 ```
+{: .language-bash}
 
 ![Example DAG plot](../fig/05-final-dag.svg)
 

--- a/_episodes/18-final-notes.md
+++ b/_episodes/18-final-notes.md
@@ -43,7 +43,7 @@ Two things before we start:
 * `&>` is a handy operator in bash that redirects both stdout and stderr to a file.
 * `&>>` does the same thing as `&>`, but appends to a file instead of overwriting it.
 
-```python
+```make
 # count words in one of our "books"
 rule count_words:
     input: 	
@@ -92,7 +92,7 @@ A token file is simply an empty file that you can create with the touch command
 (`touch some_file.txt` creates an empty file called `some_file.txt`).
 An example rule using this technique is shown below:
 
-```python
+```make
 rule token_example:
     input:  'some_file.txt'
     output: 'some_file.tkn'   # marks some_file.txt as modified


### PR DESCRIPTION
### Overview

This PR applies appropriate syntax highlighting tags, *e.g.*, `{: .language-python}`, to code blocks.
These echo the Markdown hints already present, *e.g.*, ` ```python `.

### Changes

The following changes were made:
- Prefix Bash commands with the command prompt, `$ `.
- Suffix Bash code blocks with `{: .language-bash}` tags.
- Suffix Snakemake code blocks with `{: .language-make}` tags.
- Convert Snakemake hints from ` ```python ` to ` ```make `.

### Side Effects

To take full effect, this repository must be brought up to date with the upstream [carpentries/styles](https://github.com/carpentries/styles). The outdated styling of this repository does not yet include `syntax.css`.

### Closes #6.