### PR TITLE
Python dictionaries are ordered now

### DIFF
--- a/_episodes/04-dicts.md
+++ b/_episodes/04-dicts.md
@@ -91,7 +91,6 @@ list(example.values())
 >
 > Depending on your version of Python, the dictionary will either be in order, or out of order.
 > If you are on Python 3.6+ dictionaries are ordered.
-> This is a new feature [and should not be relied upon](https://mail.python.org/pipermail/python-dev/2016-September/146348.html).
 >
 > Iterate through and print the dictionary's keys in both forward and reverse order.
 >


### PR DESCRIPTION
In python3.6, insertion order was an implementation detail and not something that can be relied on. Now with 3.7+, the order can be relied on:
https://mail.python.org/pipermail/python-dev/2017-December/151283.html
