### PR TITLE
Import ABC from collections.abc for Python 3.10 compatibility.

### DIFF
--- a/files/snakemake-lesson/plotcount.py
+++ b/files/snakemake-lesson/plotcount.py
@@ -10,7 +10,11 @@ warnings.filterwarnings("ignore")
 import numpy as np
 import matplotlib.pyplot as plt
 import sys
-from collections import Sequence
+
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from wordcount import load_word_counts
 


### PR DESCRIPTION
This fixes a deprecation warning regarding importing ABC directly from collections module which was deprecated and eventually removed in Python 3.10 to import from collections.abc module