### PR TITLE
revise Miniconda instructions

### DIFF
--- a/_episodes/13-cluster.md
+++ b/_episodes/13-cluster.md
@@ -167,16 +167,23 @@ $ tar -xvzf pipeline.tar.gz
 ```
 {: .language-bash}
 
-If Snakemake and Python are not already installed on your cluster,
-you can install them using the following commands:
+If Snakemake and Python are not already installed on your cluster, you can
+install them in an Anaconda Python environment using the following commands:
 
 ```
 $ wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-$ bash Miniconda3-latest-Linux-x86_64.sh -b
-$ echo 'export PATH=~/miniconda3/bin:~/.local/bin:$PATH' >> ~/.bashrc
-$ source ~/.bashrc
-$ conda install -y matplotlib numpy graphviz
-$ pip install --user snakemake
+$ bash Miniconda3-latest-Linux-x86_64.sh
+```
+{: .language-bash}
+
+This is an interactive installation through the command line. Review and accept
+the license agreement, then work through the prompts. The defaults are probably
+fine. Accept its offer to initialize your environment (`conda init`), then run
+the suggested command to load the `conda` base environment so you can use it
+straightaway. Finally, install Snakemake:
+
+```
+$ conda install -y -c biodonda graphviz matplotlib numpy snakemake
 ```
 {: .language-bash}
 
@@ -208,7 +215,7 @@ Here we've used SLURM's `sbatch` command and arguments for setting time limits
 and resources with snakemake wildcards defining the requested values.
 
 We've also specified where to save SLURM logs and what to call them. **Note** that
-this folder must already exist. If the folders don't exist, snakemake will hang.
+this folder must already exist. If the folders don't exist, Snakemake will hang.
 
 Values for any command line argument to snakemake can be defined in our
 profile, although a value is required (e.g. the `--use-conda` argument could be

--- a/_episodes/13-cluster.md
+++ b/_episodes/13-cluster.md
@@ -180,7 +180,7 @@ This is an interactive installation through the command line. Review and accept
 the license agreement, then work through the prompts. The defaults are probably
 fine. Accept its offer to initialize your environment (`conda init`), then run
 the suggested command to load the `conda` base environment so you can use it
-straightaway. Finally, install Snakemake from the [bioconda channel](
+straight away. Finally, install Snakemake from the [bioconda channel](
 https://anaconda.org/bioconda):
 
 ```

--- a/_episodes/13-cluster.md
+++ b/_episodes/13-cluster.md
@@ -180,10 +180,11 @@ This is an interactive installation through the command line. Review and accept
 the license agreement, then work through the prompts. The defaults are probably
 fine. Accept its offer to initialize your environment (`conda init`), then run
 the suggested command to load the `conda` base environment so you can use it
-straightaway. Finally, install Snakemake:
+straightaway. Finally, install Snakemake from the [bioconda channel](
+https://anaconda.org/bioconda):
 
 ```
-$ conda install -y -c biodonda graphviz matplotlib numpy snakemake
+$ conda install -y -c bioconda graphviz matplotlib numpy snakemake
 ```
 {: .language-bash}
 

--- a/index.md
+++ b/index.md
@@ -35,7 +35,7 @@ At the end of this lesson, you will know how to:
 > <https://docs.conda.io/en/latest/miniconda.html>.
 > 
 > To install snakemake, please run the following in a command-line terminal:
-> `conda install snakemake`
+> `conda install -c bioconda snakemake`
 >
 > The files used in this lesson can be downloaded
 > [here](files/snakemake-lesson.zip).

--- a/setup.md
+++ b/setup.md
@@ -17,12 +17,13 @@ includes several significant performance improvements over "vanilla" Python.
 
 ## Snakemake
 
-Once you have a Miniconda environment configured, please install Snakemake with
+Once you have a Miniconda environment configured, please install Snakemake from
+the [bioconda channel](https://anaconda.org/bioconda) with
 
 ```
-conda install snakemake
+$ conda install -c bioconda snakemake
 ```
-{: .source}
+{: .language-bash}
 
 ## Shell and SSH
 


### PR DESCRIPTION
Learners should not explicitly change their `.bashrc` on conda's behalf, among other things.